### PR TITLE
fix: Incident: error_burst (error_burst:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
     res.status(401).json({ error: "Unauthorized" });
   });
 
-  if (process.env.SIMULATE_INCIDENTS === "true") {
+  if (process.env.SIMULATE_INCIDENTS === "true" && process.env.NODE_ENV !== "production") {
     setInterval(() => {
       logger.error(
         {


### PR DESCRIPTION
# Summary

## What changed
Disable synthetic error burst generation in production environments.

## Why
The incident 'error_burst' is triggered by synthetic error generation, which is enabled when `SIMULATE_INCIDENTS` is set to 'true'. This patch adds an additional check for `NODE_ENV !== "production"` to prevent these synthetic error bursts from being generated in production while retaining the functionality for non-production environments where it might be used for testing incident detection.

## Test plan
- Deploy the patched application to a staging environment with `SIMULATE_INCIDENTS=true` and `NODE_ENV=development`. Verify that synthetic error bursts for `/api/orders` are still generated.
- Deploy the patched application to a production-like environment with `SIMULATE_INCIDENTS=true` and `NODE_ENV=production`. Verify that synthetic error bursts for `/api/orders` are NO LONGER generated.
- Monitor production logs after deployment to confirm the absence of 'Synthetic error burst' messages and a reduction in the reported 'error_burst' incidents.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Diff apply used

Closes #42