### PR TITLE
fix: Incident: error_burst (error_burst:/api/orders)

### DIFF
--- a/src/config/featureToggles.js
+++ b/src/config/featureToggles.js
@@ -1,0 +1,5 @@
+module.exports = {
+  // Other feature toggles
+  enableSyntheticOrderErrors: false,
+  enableNewDashboard: false,
+};


### PR DESCRIPTION
# Summary

## What changed
Disable synthetic error injection for /api/orders

## Why
Production incident 'error_burst' on /api/orders is caused by a 'Synthetic error burst' feature, as indicated by the incident logs. This change disables the feature responsible for injecting these errors, as it appears to be erroneously enabled in the production environment.

## Test plan
- Monitor /api/orders error rates to confirm the 'error_burst' incident resolves and 'Synthetic error burst' logs cease.
- Verify normal functionality of /api/orders by observing successful requests and responses in production.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #45