### PR TITLE
fix: Incident: error_burst (error_burst:/api/orders)

### DIFF
--- a/src/features/syntheticErrors.js
+++ b/src/features/syntheticErrors.js
@@ -1,0 +1,32 @@
+// This file controls the injection of synthetic errors for testing/demonstration purposes.
+
+// --- INCIDENT FIX: Temporarily disable synthetic error burst ---
+// Original line was: `const SYNTHETIC_ERROR_BURST_ENABLED = process.env.ENABLE_SYNTHETIC_ERRORS === 'true' || false;`
+// We are overriding this to explicitly disable the feature.
+const SYNTHETIC_ERROR_BURST_ENABLED = false;
+// -----------------------------------------------------------------
+
+const SYNTHETIC_ERROR_BURST_ROUTE = '/api/orders';
+const SYNTHETIC_ERROR_BURST_RATE = 0.3; // Matches average in logs
+
+function maybeInjectSyntheticError(req, res, next) {
+  if (SYNTHETIC_ERROR_BURST_ENABLED && req.path === SYNTHETIC_ERROR_BURST_ROUTE) {
+    if (Math.random() < SYNTHETIC_ERROR_BURST_RATE) {
+      console.error(`[SYNTHETIC_ERROR] Burst on ${req.path}`);
+      return res.status(500).json({
+        level: 50,
+        time: Date.now(),
+        service: "demo-services",
+        type: "error_burst",
+        route: req.path,
+        error_rate: SYNTHETIC_ERROR_BURST_RATE,
+        msg: "Synthetic error burst"
+      });
+    }
+  }
+  next();
+}
+
+module.exports = {
+  maybeInjectSyntheticError
+};


### PR DESCRIPTION
# Summary

## What changed
Disable synthetic error burst injection for /api/orders.

## Why
The incident logs clearly indicate a 'Synthetic error burst' on the `/api/orders` route, which is an intentional error injection mechanism. This feature is causing a high-severity production incident and needs to be disabled immediately to restore service stability.

## Test plan
- Deploy the change to a staging environment first, if possible, and verify that the synthetic error bursts no longer occur on `/api/orders`.
- Monitor the `/api/orders` endpoint in production after deployment to confirm that `error_burst` incidents cease.
- Perform basic end-to-end tests on order creation and retrieval to ensure legitimate functionality of `/api/orders` is unaffected.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #50