### PR TITLE
fix: Incident: error_burst (error_burst:/api/orders)

### DIFF
--- a/src/main/java/com/example/demoservices/order/OrderService.java
+++ b/src/main/java/com/example/demoservices/order/OrderService.java
@@ -1,0 +1,34 @@
+package com.example.demoservices.order;
+
+import org.springframework.stereotype.Service;
+import java.util.Random;
+
+@Service
+public class OrderService {
+
+    private static final Random random = new Random();
+    // Incident: error_burst on /api/orders due to synthetic errors. Temporarily disabling this feature in production.
+    private static final boolean SYNTHETIC_ERROR_ENABLED = false; // Changed from 'true' to 'false' to mitigate incident
+    private static final double SYNTHETIC_ERROR_RATE = 0.35; // The rate at which synthetic errors were introduced
+
+    public String processOrder(String orderId, String item, int quantity) {
+        // Simulate some processing time for order placement
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // Log the interruption or handle it as appropriate
+        }
+
+        // Check for synthetic error burst condition
+        if (SYNTHETIC_ERROR_ENABLED && random.nextDouble() < SYNTHETIC_ERROR_RATE) {
+            System.err.println("Generating synthetic error for order: " + orderId);
+            throw new RuntimeException("Synthetic error burst");
+        }
+
+        // Actual order processing logic would continue here
+        String processingStatus = "Order " + orderId + " for " + quantity + "x " + item + " processed successfully.";
+        System.out.println(processingStatus);
+        return processingStatus;
+    }
+}


### PR DESCRIPTION
# Summary

## What changed
Disable synthetic error burst for /api/orders endpoint

## Why
The production system is experiencing a high-severity error burst on the `/api/orders` endpoint, clearly identified by the log message 'Synthetic error burst'. This indicates a chaos engineering or demo feature is active in a production environment, generating artificial errors. Disabling this feature by setting its controlling flag to `false` will immediately mitigate the incident.

## Test plan
- Deploy the updated `demo-services` application.
- Monitor application logs for 'demo-services' to confirm the absence of 'Synthetic error burst' log messages related to `/api/orders`.
- Verify the success rate of `/api/orders` endpoint requests has returned to normal (100% or expected production levels) using monitoring tools.
- Perform functional tests on the order processing functionality via `/api/orders` to ensure it works as expected without artificial failures.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #58