### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,81 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import pino from 'pino';
+
+const app = express();
+const port = 3000;
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  formatters: {
+    level: (label) => ({ level: label }),
+  },
+  timestamp: () => `,"time":${Date.now()}`,
+});
+
+app.use(bodyParser.json());
+
+interface OrderItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+interface Order {
+  userId: string;
+  items: OrderItem[];
+  total: number;
+  status: 'pending' | 'completed' | 'failed';
+  createdAt: number;
+}
+
+const orders: Order[] = []; // In-memory store for simplicity
+
+app.get('/health', (req, res) => {
+  res.status(200).send('OK');
+});
+
+app.post('/api/orders', (req, res) => {
+  try {
+    const { userId, items } = req.body;
+
+    if (!userId) {
+      logger.warn({ type: 'validation_error', route: '/api/orders', msg: 'Missing userId' });
+      return res.status(400).json({ error: 'userId is required' });
+    }
+
+    // FIX: Ensure 'items' is an array before attempting to call 'reduce()'.
+    // The error `Cannot read properties of null (reading 'reduce')` indicates `items` itself is null or undefined.
+    const safeItems = Array.isArray(items) ? items : [];
+    
+    // The original error occurred on the next line when 'items' was null/undefined.
+    const total = safeItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+    const newOrder: Order = {
+      userId,
+      items: safeItems, // Use the now-guaranteed-to-be-array 'safeItems'
+      total,
+      status: 'pending',
+      createdAt: Date.now(),
+    };
+
+    orders.push(newOrder);
+    logger.info({ type: 'order_created', route: '/api/orders', orderId: newOrder.createdAt, userId });
+    res.status(201).json(newOrder);
+
+  } catch (error: any) {
+    logger.error({
+      level: 'error',
+      type: 'null_reference_order_items', // Keeping original error type for consistency in monitoring
+      route: '/api/orders',
+      error: error.message,
+      stack: error.stack,
+      msg: `CRITICAL: /api/orders crashed — ${error.message}`,
+    });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.listen(port, () => {
+  logger.info(`Server running on port ${port}`);
+});


### PR DESCRIPTION
# Summary

## What changed
Safeguard order items collection from null/undefined values to prevent 'reduce' errors.

## Why
The incident logs indicate a `TypeError: Cannot read properties of null (reading 'reduce')` occurring at `src/index.ts:61:60` when processing `/api/orders` requests. This error happens when `req.body.items` is `null` or `undefined`, and `reduce()` is subsequently called on it. The fix ensures that `items` is always treated as an array (defaulting to an empty array if `null` or `undefined`) before `reduce()` is invoked, preventing the application from crashing.

## Test plan
- 1. Replicate incident: Send a POST request to `/api/orders` with `userId: 'test-user'` and `items: null` in the request body. Verify a 500 status code and `null_reference_order_items` error in logs.
- 2. Test fix (null items): Send a POST request to `/api/orders` with `userId: 'test-user'` and `items: null`. Verify a 201 status code and that the order's `total` is calculated as 0.
- 3. Test fix (undefined items - omit items): Send a POST request to `/api/orders` with only `userId: 'test-user'` (i.e., `items` is not provided in the body). Verify a 201 status code and that the order's `total` is calculated as 0.
- 4. Test fix (empty array items): Send a POST request to `/api/orders` with `userId: 'test-user'` and `items: []`. Verify a 201 status code and that the order's `total` is calculated as 0.
- 5. Test valid items: Send a POST request to `/api/orders` with `userId: 'test-user'` and `items: [{productId: 'A', quantity: 2, price: 10}, {productId: 'B', quantity: 1, price: 5}]`. Verify a 201 status code and the `total` calculated correctly as 25.
- 6. Monitor production logs for any recurrence of `null_reference_order_items` errors related to `/api/orders`.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #65