### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,58 @@
+import express, { Request, Response } from 'express';
+import bodyParser from 'body-parser';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(bodyParser.json());
+
+// Placeholder for some data or a mock database
+interface OrderItem {
+  productId: string;
+  price: number;
+  quantity: number;
+}
+
+interface Order {
+  id: string;
+  userId: string;
+  items: OrderItem[];
+  totalPrice: number;
+  status: 'pending' | 'completed' | 'cancelled';
+  createdAt: string;
+}
+
+const orders: Order[] = [];
+let orderIdCounter = 1;
+
+app.get('/', (req: Request, res: Response) => {
+  res.send('Order Service is running!');
+});
+
+// Incident-related route
+app.post('/api/orders', (req: Request, res: Response) => {
+  const { userId, items } = req.body; // items could be null or undefined
+
+  if (!userId) {
+    return res.status(400).json({ error: 'User ID is required' });
+  }
+
+  // Fix: Use nullish coalescing to default `items` to an empty array if null/undefined
+  const totalPrice = (items ?? []).reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  const newOrder: Order = {
+    id: `order-${orderIdCounter++}`,
+    userId,
+    items: items ?? [], // Ensure items is an array in the stored order as well
+    totalPrice,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  };
+
+  orders.push(newOrder);
+  res.status(201).json(newOrder);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
# Summary

## What changed
Safely handle null or undefined `items` array when calculating order total.

## Why
The incident report indicates a `TypeError: Cannot read properties of null (reading 'reduce')` at `src/index.ts:61:60` when processing `/api/orders`. This occurs when the `items` property in the request body is `null` or `undefined`, and `reduce()` is called directly on it. The change adds a nullish coalescing operator (`?? []`) to ensure that `reduce()` is always called on an array, defaulting to an empty array if `items` is missing or null, thus preventing the crash and setting the `totalPrice` to 0 for such cases.

## Test plan
- Deploy the change to a staging environment.
- Submit a POST request to `/api/orders` with a valid `userId` and an `items` array, verify the order is created successfully with the correct `totalPrice`.
- Submit a POST request to `/api/orders` with a valid `userId` and an empty `items` array (`items: []`), verify the order is created successfully with `totalPrice: 0`.
- Submit a POST request to `/api/orders` with a valid `userId` and `items: null`, verify the order is created successfully with `totalPrice: 0`.
- Submit a POST request to `/api/orders` with a valid `userId` but *without* the `items` property in the request body, verify the order is created successfully with `totalPrice: 0`.
- Monitor error logs for `TypeError: Cannot read properties of null (reading 'reduce')` after deployment.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #67