### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Safely handle null or undefined `items` in order processing to prevent crashes.

## Why
The incident logs indicate a `TypeError: Cannot read properties of null (reading 'reduce')` originating from `src/index.ts:61:60`. This occurs when the `items` field in the request body for `/api/orders` is null or undefined, leading to a critical production incident where all orders fail. The fix changes `items` to `(items ?? [])` to provide a default empty array, preventing the `.reduce()` call from throwing a TypeError.

## Test plan
- Run unit tests to ensure existing functionality is not broken.
- Deploy to a staging environment.
- Send a POST request to `/api/orders` with an empty `items` array: `{"items": []}`. Expect a total of 0 and a 200 OK response.
- Send a POST request to `/api/orders` with valid items: `{"items": [{"price": 10, "qty": 2}]}`. Expect a total of 20 and a 200 OK response.
- Send a POST request to `/api/orders` with `items` explicitly set to `null`: `{"items": null}`. Expect a 200 OK response with total 0 (no crash).
- Send a POST request to `/api/orders` without the `items` field in the body: `{}`. Expect a 200 OK response with total 0 (no crash).

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #71