### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Fix null reference error in /api/orders endpoint by guarding 'items' before calling .reduce().

## Why
The incident report 'null_reference_order_items' indicates a TypeError when 'items' is null or undefined, causing the server to crash on the `/api/orders` route. The stack trace points to `src/index.ts:61:60` (which is line 62 in the provided context, referencing the `reduce` call). The fix applies a nullish coalescing operator (`?? []`) to `items` before attempting to call `.reduce()`, ensuring that `reduce` is always called on an array, preventing the crash. This aligns with the 'INTENTIONAL CRITICAL BUG' comment in the code.

## Test plan
- Spin up the `demo-services` application.
- Send a POST request to `/api/orders` with a valid body, e.g., `{"items": [{"price": 10, "qty": 2}]}`. Verify a 200 OK response and correct total.
- Send a POST request to `/api/orders` with `items: null`, e.g., `{"items": null}`. Verify a 200 OK response with `{"ok": true, "total": 0}` and no server crash.
- Send a POST request to `/api/orders` without an `items` field in the body, e.g., `{}`. Verify a 200 OK response with `{"ok": true, "total": 0}` and no server crash.
- Send a POST request to `/api/orders` with an empty request body. Verify a 200 OK response with `{"ok": true, "total": 0}` and no server crash.

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #74