### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -50,14 +50,11 @@ async function main(): Promise<void> {
     res.status(401).json({ error: "Unauthorized" });
   });
 
-  // INTENTIONAL CRITICAL BUG: `items` is not null-guarded before `.reduce()`.
-  // When the request body omits `items` (or sends null), this throws:
-  //   TypeError: Cannot read properties of null (reading 'reduce')
-  // Fix: change `items` → `(items ?? [])` on the reduce call.
+  // FIXED: Added null guard (items ?? []) to prevent null reference error
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Fix null reference error in /api/orders endpoint by adding null guard for items array

## Why
The /api/orders endpoint crashes with 'Cannot read properties of null (reading 'reduce')' when the request body is missing the 'items' field or when items is null. The error occurs at line 61 where items.reduce() is called without null checking. This is causing 88-99% error rate and all orders are failing. The fix adds a null coalescing operator to default items to an empty array before calling reduce().

## Test plan
- Deploy the fix to production
- Send POST request to /api/orders with empty body {} - should return {ok: true, total: 0} instead of 500 error
- Send POST request to /api/orders with null items {items: null} - should return {ok: true, total: 0} instead of 500 error
- Send POST request to /api/orders with valid items {items: [{price: 10, qty: 2}]} - should return {ok: true, total: 20}
- Monitor error logs for null_reference_order_items - should drop to 0
- Monitor error_rate metric for /api/orders - should drop from 88-99% to near 0%

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #81