### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -50,14 +50,11 @@ async function main(): Promise<void> {
     res.status(401).json({ error: "Unauthorized" });
   });
 
-  // INTENTIONAL CRITICAL BUG: `items` is not null-guarded before `.reduce()`.
-  // When the request body omits `items` (or sends null), this throws:
-  //   TypeError: Cannot read properties of null (reading 'reduce')
-  // Fix: change `items` → `(items ?? [])` on the reduce call.
+  // FIXED: Added null guard (items ?? []) to prevent null reference error
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Fix null reference error in /api/orders endpoint by adding null guard for items array

## Why
The /api/orders endpoint is crashing with 'Cannot read properties of null (reading 'reduce')' because the code attempts to call .reduce() on items without checking if it's null or undefined. When clients send requests without an 'items' field in the body, items is undefined/null, causing the crash. The fix adds a null coalescing operator to default to an empty array.

## Test plan
- Deploy the fix to production
- Test POST /api/orders with valid items array: {"items": [{"price": 10, "qty": 2}]} - should return {"ok": true, "total": 20}
- Test POST /api/orders with missing items field: {} - should return {"ok": true, "total": 0} instead of 500 error
- Test POST /api/orders with null items: {"items": null} - should return {"ok": true, "total": 0} instead of 500 error
- Monitor error logs for null_reference_order_items - should drop to zero
- Monitor error rate on /api/orders endpoint - should return to normal levels

**Test results**
```

```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: :
- Rewrite fallback used

Closes #85