### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -50,14 +50,11 @@ async function main(): Promise<void> {
     res.status(401).json({ error: "Unauthorized" });
   });
 
-  // INTENTIONAL CRITICAL BUG: `items` is not null-guarded before `.reduce()`.
-  // When the request body omits `items` (or sends null), this throws:
-  //   TypeError: Cannot read properties of null (reading 'reduce')
-  // Fix: change `items` → `(items ?? [])` on the reduce call.
+  // FIXED: Added null guard (items ?? []) to prevent null reference error
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Fix null reference error in /api/orders endpoint by adding null guard for items array

## Why
The /api/orders endpoint is crashing with 'Cannot read properties of null (reading 'reduce')' because the items field is not validated before calling .reduce(). When clients send requests without the items field or with null items, the code attempts to call .reduce() on null/undefined, causing a TypeError. This is causing 84%+ error rate and all orders are failing. The fix adds a null coalescing operator to default items to an empty array.

## Test plan
- Deploy the fix to production
- Send POST request to /api/orders with empty body {} - should return {ok: true, total: 0} instead of 500 error
- Send POST request to /api/orders with null items {items: null} - should return {ok: true, total: 0}
- Send POST request to /api/orders with valid items {items: [{price: 10, qty: 2}]} - should return {ok: true, total: 20}
- Monitor error logs for null_reference_order_items - should drop to 0
- Monitor error_rate metric - should return to normal levels
- Verify order processing is restored for all customers

**Test results**
```

> incident-orchestration-agent@0.1.0 test
> npm --workspace @agentic/agent run test


> @agentic/agent@0.1.0 test
> vitest run --reporter=basic


 RUN  v2.1.9 /app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/packages/agent

 ✓ src/memory/postgres.test.ts (19 tests) 14ms
 ✓ src/connectors/registry.test.ts (41 tests) 28ms
 ✓ src/memory/repo.test.ts (21 tests) 23ms
 ✓ src/activities/incidentActivities.test.ts (26 tests) 20ms
 ✓ src/rag/retrieveRepo.test.ts (3 tests) 8ms
 ✓ src/rag/indexRepo.test.ts (20 tests) 22ms
 ✓ src/rag/repoCache.test.ts (11 tests) 24ms
 ✓ src/lib/git.test.ts (6 tests) 17ms
 ✓ src/lib/retry.test.ts (7 tests) 22ms
 ✓ src/lib/github.test.ts (12 tests) 14ms
 ✓ src/lib/repoTarget.test.ts (30 tests) 16ms
 ✓ src/connectors/source/loki.test.ts (15 tests) 25ms
 ✓ src/tools/dockerSandbox.test.ts (12 tests) 18ms
 ✓ src/lib/crypto.test.ts (11 tests) 14ms
stderr | src/lib/loki.test.ts > queryLoki > returns empty array and warns when data.result is missing
[WARN] Loki response missing expected data.result structure {"payload":"{\"data\":{\"resultType\":\"streams\"}}"}

stderr | src/lib/loki.test.ts > queryLoki > returns empty array when payload is not an object
[WARN] Loki response missing expected data.result structure {"payload":"null"}

stderr | src/lib/loki.test.ts > queryLoki > returns empty array when data field is missing
[WARN] Loki response missing expected data.result structure {"payload":"{\"status\":\"200 OK\"}"}

 ✓ src/lib/loki.test.ts (11 tests) 26ms
 ✓ src/autofix/autoFix.test.ts (77 tests) 84ms
(node:228) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
stderr | src/lib/configLoader.test.ts > polling interval > keeps previous config if a poll throws
[configLoader] Poll failed, keeping previous config: Error: DB timeout
    at /app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/packages/agent/src/lib/configLoader.test.ts:202:7
    at file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:533:5
    at runTest (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:1056:11)
    at runSuite (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:1205:15)
    at runSuite (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:1205:15)
    at runFiles (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:1262:5)
    at startTests (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/@vitest/runner/dist/index.js:1271:3)
    at file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:126:11
    at withEnv (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:90:5)
    at run (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-OeAsYE/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:112:3)

 ✓ src/lib/configLoader.test.ts (15 tests) 68ms
 ✓ src/lib/embeddings.test.ts (15 tests) 18ms
 ✓ src/lib/severity.test.ts (6 tests) 4ms
 ✓ src/lib/llm.test.ts (57 tests) 784ms
   ✓ resolveProvider > selects the correct provider/model for explicit keys 319ms

 Test Files  20 passed (20)
      Tests  415 passed (415)
   Start at  01:11:14
   Duration  1.51s (transform 3.59s, setup 0ms, collect 5.73s, tests 1.25s, environment 6ms, prepare 4.16s)


```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: npm test
- Rewrite fallback used

Closes #90