### PR TITLE
fix: Incident: null_reference_order_items (critical:/api/orders)

### DIFF
--- a/apps/demo-services/src/index.ts
+++ b/apps/demo-services/src/index.ts
@@ -50,14 +50,11 @@ async function main(): Promise<void> {
     res.status(401).json({ error: "Unauthorized" });
   });
 
-  // INTENTIONAL CRITICAL BUG: `items` is not null-guarded before `.reduce()`.
-  // When the request body omits `items` (or sends null), this throws:
-  //   TypeError: Cannot read properties of null (reading 'reduce')
-  // Fix: change `items` → `(items ?? [])` on the reduce call.
+  // FIXED: Added null guard (items ?? []) to prevent null reference error
   app.post("/api/orders", (req, res) => {
     try {
       const { items } = req.body ?? {};
-      const total = (items as Array<{ price: number; qty: number }>).reduce(
+      const total = ((items ?? []) as Array<{ price: number; qty: number }>).reduce(
         (sum, item) => sum + item.price * item.qty,
         0,
       );


### PR DESCRIPTION
# Summary

## What changed
Fix null reference error in /api/orders endpoint by adding null guard for items array

## Why
The /api/orders endpoint is crashing with 'Cannot read properties of null (reading 'reduce')' because the items field is not validated before calling .reduce(). When requests are sent without an items field or with null items, the code attempts to call .reduce() on null/undefined, causing a TypeError. This is affecting 80-99% of order requests based on the error_rate in logs. The fix adds a null coalescing operator to default items to an empty array.

## Test plan
- Deploy the fix to production
- Send POST request to /api/orders with empty body {} - should return {ok: true, total: 0} instead of 500 error
- Send POST request to /api/orders with null items {items: null} - should return {ok: true, total: 0}
- Send POST request to /api/orders with valid items [{price: 10, qty: 2}] - should return {ok: true, total: 20}
- Monitor error logs for null_reference_order_items - should drop to 0 occurrences
- Monitor error_rate metric for /api/orders - should drop from 80-99% to near 0%
- Verify order processing is restored for all customers

**Test results**
```

> incident-orchestration-agent@0.1.0 test
> npm --workspace @agentic/agent run test


> @agentic/agent@0.1.0 test
> vitest run --reporter=basic


 RUN  v2.1.9 /app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/packages/agent

 ✓ src/activities/incidentActivities.test.ts (26 tests) 26ms
 ✓ src/rag/indexRepo.test.ts (20 tests) 28ms
 ✓ src/memory/postgres.test.ts (19 tests) 21ms
 ✓ src/rag/retrieveRepo.test.ts (3 tests) 13ms
 ✓ src/memory/repo.test.ts (21 tests) 34ms
 ✓ src/rag/repoCache.test.ts (11 tests) 38ms
 ✓ src/lib/crypto.test.ts (11 tests) 19ms
 ✓ src/lib/git.test.ts (6 tests) 12ms
 ✓ src/lib/retry.test.ts (7 tests) 24ms
 ✓ src/connectors/registry.test.ts (41 tests) 48ms
 ✓ src/tools/dockerSandbox.test.ts (12 tests) 16ms
 ✓ src/connectors/source/loki.test.ts (15 tests) 18ms
 ✓ src/lib/repoTarget.test.ts (30 tests) 13ms
 ✓ src/lib/github.test.ts (12 tests) 11ms
 ✓ src/autofix/autoFix.test.ts (77 tests) 80ms
stderr | src/lib/loki.test.ts > queryLoki > returns empty array and warns when data.result is missing
[WARN] Loki response missing expected data.result structure {"payload":"{\"data\":{\"resultType\":\"streams\"}}"}

stderr | src/lib/loki.test.ts > queryLoki > returns empty array when payload is not an object
[WARN] Loki response missing expected data.result structure {"payload":"null"}

stderr | src/lib/loki.test.ts > queryLoki > returns empty array when data field is missing
[WARN] Loki response missing expected data.result structure {"payload":"{\"status\":\"200 OK\"}"}

 ✓ src/lib/loki.test.ts (11 tests) 20ms
 ✓ src/lib/severity.test.ts (6 tests) 8ms
(node:243) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
stderr | src/lib/configLoader.test.ts > polling interval > keeps previous config if a poll throws
[configLoader] Poll failed, keeping previous config: Error: DB timeout
    at /app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/packages/agent/src/lib/configLoader.test.ts:202:7
    at file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:533:5
    at runTest (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:1056:11)
    at runSuite (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:1205:15)
    at runSuite (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:1205:15)
    at runFiles (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:1262:5)
    at startTests (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/@vitest/runner/dist/index.js:1271:3)
    at file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:126:11
    at withEnv (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:90:5)
    at run (file:///app/packages/agent/.agentic/repos/.workspaces/agentic-fix-h9oruI/repo/node_modules/vitest/dist/chunks/runBaseTests.3qpJUEJM.js:112:3)

 ✓ src/lib/configLoader.test.ts (15 tests) 70ms
 ✓ src/lib/embeddings.test.ts (15 tests) 17ms
 ✓ src/lib/llm.test.ts (57 tests) 873ms
   ✓ resolveProvider > selects the correct provider/model for explicit keys 363ms

 Test Files  20 passed (20)
      Tests  415 passed (415)
   Start at  01:13:57
   Duration  1.78s (transform 4.40s, setup 0ms, collect 8.23s, tests 1.39s, environment 8ms, prepare 4.01s)


```
- [ ] `npm run test`
- [ ] `npm run healthcheck`
- [ ] Manual verification (describe)

## Checklist
- [ ] Docs updated (if needed)
- [ ] No secrets added

## Safety checks
- Denylist check passed (1 files)
- Sandbox tests passed: npm test
- Rewrite fallback used

Closes #92